### PR TITLE
speed up group_by operations with mutate

### DIFF
--- a/man/plyranges-package.Rd
+++ b/man/plyranges-package.Rd
@@ -44,7 +44,7 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Stuart Lee \email{lee.s@wehi.edu.au} (\href{https://orcid.org/0000-0003-1179-8436}{ORCID})
+\strong{Maintainer}: Stuart Lee \email{stuart.andrew.lee@gmail.com} (\href{https://orcid.org/0000-0003-1179-8436}{ORCID})
 
 Authors:
 \itemize{


### PR DESCRIPTION
When operating on an ungrouped object, `mutate` will use methods from {plyranges} but when operating on a grouped object, `mutate` will rely on vanilla tidyverse by converting the object to a tibble. The result is then coerced back to `DataFrame` to update the metadata of the object. Of note, core columns can be used in this framework to create new metadata columns.